### PR TITLE
Support paths with spaces when running `hreports save`

### DIFF
--- a/hreports/hreports.py
+++ b/hreports/hreports.py
@@ -214,7 +214,7 @@ class Hreport(object):
 
         output_file = self.render_string(output_file, name)
 
-        cmd = 'pandoc %s -t html5 -o %s' % (input_file.name,
+        cmd = 'pandoc "%s" -t html5 -o "%s"' % (input_file.name,
                                             output_file)
 
         styling = self.get_report_config_value(name, 'styling')

--- a/hreports/hreports.py
+++ b/hreports/hreports.py
@@ -3,6 +3,7 @@
 """Main module."""
 
 import os
+from sys import stdout
 import io
 import subprocess
 import datetime
@@ -90,6 +91,7 @@ class Hreport(object):
         try:
             cmd_list = split_arg_string(cmd)
             output = subprocess.check_output(cmd_list)
+            output = output.decode(stdout.encoding)
             self.config.returncode = 0
 
         except OSError:


### PR DESCRIPTION
Pandoc was failing when running `hreports save reportname` on a path with spaces as paths passed to the pandoc command weren't quoted. Error message below:

> hreports save balance
>
> pandoc: /Users/user/Documents/Self: openBinaryFile: does not exist (No such file or directory)
> Usage: hreports save [OPTIONS] [NAME]
>
> Error: Pandoc pandoc /Users/user/Documents/Self Employment/Accounts/tmpPcTEef -t html5 -o balance.pdf returned non-zero exit status

I changed the pandoc command in hreports.py on my local machine and the paths that were failing now work as expected.